### PR TITLE
Refactor / DNS assignment actually works

### DIFF
--- a/lib/aws_wrapper.rb
+++ b/lib/aws_wrapper.rb
@@ -1,13 +1,7 @@
-require 'singleton'
 require_relative 'dns_wrapper'
 require_relative 'ec2_wrapper'
 
 class AwsWrapper
   include DnsWrapper
   include Ec2Wrapper
-  include Singleton
-  
-  def initialize
-    super
-  end
 end

--- a/lib/base_wrapper.rb
+++ b/lib/base_wrapper.rb
@@ -14,6 +14,7 @@ module BaseWrapper
   LOGGER.formatter = proc do |severity, datetime, _progname, msg|
     "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S')}]: #{msg}\n"
   end
+  
   CLIENT_CONFIG = {
     logger: LOGGER, 
     log_level: :debug,
@@ -23,10 +24,5 @@ module BaseWrapper
   
   WAIT_INTERVAL = 5
   WAIT_ATTEMPTS = 100
-  
-  def logger
-    # TODO: either the const or the method, not both
-    LOGGER
-  end
   
 end

--- a/lib/dns_wrapper.rb
+++ b/lib/dns_wrapper.rb
@@ -4,9 +4,19 @@ require 'resolv'
 module DnsWrapper
   include BaseWrapper
   
-  def initialize
-    super
-    @dns_client = Aws::Route53::Client.new(CLIENT_CONFIG)
+  private
+  
+  def dns_client
+    @dns_client ||= Aws::Route53::Client.new(CLIENT_CONFIG)
+  end
+  
+  public
+  
+  def lookup_dns(domain_name)
+    aws_ip = lookup_dns_a_record(ZONE_ID, domain_name)
+    dns_ip = Resolv.getaddress(domain_name)
+    fail("Discrepancy for #{domain_name}: AWS=#{aws_ip} but DNS=#{dns_ip}") unless dns_ip == aws_ip
+    dns_ip
   end
   
   def update_dns_a_record(zone_id, domain_name, new_ip)
@@ -28,7 +38,7 @@ module DnsWrapper
   end
   
   def update_insync?(update_request_response)
-    response = @dns_client.get_change({
+    response = dns_client.get_change({
       id: update_request_response.change_info.id
     })
     response.change_info.status == 'INSYNC'
@@ -38,7 +48,7 @@ module DnsWrapper
   end
   
   def lookup_dns_a_record(zone_id, domain_name)
-    response = @dns_client.list_resource_record_sets({
+    response = dns_client.list_resource_record_sets({
       hosted_zone_id: zone_id, # required
       start_record_name: domain_name, # NOT a filter: all are returned, unless max_items set.
       start_record_type: 'A', # accepts SOA, A, TXT, NS, CNAME, MX, PTR, SRV, SPF, AAAA
@@ -59,7 +69,7 @@ module DnsWrapper
     if Resolv.getaddress(domain_name) == new_ip
       fail("DNS says #{domain_name} already has IP #{new_ip}")
     end
-    @dns_client.change_resource_record_sets({
+    dns_client.change_resource_record_sets({
       hosted_zone_id: zone_id, # required
       change_batch: { # required
         # comment: "ResourceDescription",

--- a/lib/dns_wrapper.rb
+++ b/lib/dns_wrapper.rb
@@ -12,8 +12,8 @@ module DnsWrapper
   
   public
   
-  def lookup_dns(domain_name)
-    aws_ip = lookup_dns_a_record(ZONE_ID, domain_name)
+  def lookup_dns(zone_id, domain_name)
+    aws_ip = lookup_dns_a_record(zone_id, domain_name)
     dns_ip = Resolv.getaddress(domain_name)
     fail("Discrepancy for #{domain_name}: AWS=#{aws_ip} but DNS=#{dns_ip}") unless dns_ip == aws_ip
     dns_ip

--- a/lib/eip_dns_swapper.rb
+++ b/lib/eip_dns_swapper.rb
@@ -1,0 +1,35 @@
+require_relative 'aws_wrapper'
+
+class EipDnsSwapper < AwsWrapper
+  def swap(base_name, zone_id)
+    live_domain_name = base_name
+    demo_domain_name = "demo.#{live_domain_name}"
+    
+    eip_ip = lookup_dns(zone_id, live_domain_name)
+    demo_ip = lookup_dns(zone_id, demo_domain_name)
+    fail("Live and demo are both #{demo_ip}") if eip_ip == demo_ip
+
+    live_instance_id = lookup_eip(eip_ip).instance_id
+
+    demo_instance = lookup_ip(demo_ip)
+
+    LOGGER.info("About to assign EIP #{eip_ip} to former demo instance (#{demo_instance.instance_id})...")
+    assign_eip(eip_ip, demo_instance)
+    LOGGER.info("ASSIGNED EIP #{eip_ip} to #{lookup_eip(eip_ip).instance_id}")
+
+    # At this point the live_instance object is out of date:
+    # The object's public_ip_address is actually still the EIP.
+    # So, look it up again:
+
+    former_live_instance = nil # For scope
+    begin
+      sleep WAIT_INTERVAL
+      former_live_instance = lookup_instance(live_instance_id)
+      LOGGER.info("Instance #{live_instance_id} has ip: #{former_live_instance.public_ip_address}")
+    end until former_live_instance && former_live_instance.public_ip_address
+
+    LOGGER.info("About to assign DNS #{demo_domain_name} to former live instance IP (#{former_live_instance.public_ip_address})...")
+    update_dns_a_record(zone_id, demo_domain_name, former_live_instance.public_ip_address)
+    LOGGER.info("ASSIGNED DNS #{demo_domain_name} to #{lookup_dns(zone_id, demo_domain_name)}")
+  end
+end

--- a/scripts/swap_both.rb
+++ b/scripts/swap_both.rb
@@ -17,12 +17,25 @@ AwsWrapper.new.tap do |aws|
   fail("Live and demo are both #{demo_ip}") if eip_ip == demo_ip
 
   live_instance_id = aws.lookup_eip(eip_ip).instance_id
-  live_instance = aws.lookup_instance(live_instance_id)
 
   demo_instance = aws.lookup_ip(demo_ip)
 
-  aws.class::LOGGER.info("About to assign EIP (#{eip_ip}) to former demo instance...")
+  aws.class::LOGGER.info("About to assign EIP #{eip_ip} to former demo instance (#{demo_instance.instance_id})...")
   aws.assign_eip(eip_ip, demo_instance)
-  aws.class::LOGGER.info("About to assign #{demo_domain_name} to former live instance...")
-  aws.update_dns_a_record(ZONE_ID, demo_domain_name, live_instance.public_ip_address)
+  aws.class::LOGGER.info("ASSIGNED EIP #{eip_ip} to #{aws.lookup_eip(eip_ip).instance_id}")
+  
+  # At this point the live_instance object is out of date:
+  # The object's public_ip_address is actually still the EIP.
+  # So, look it up again:
+  
+  former_live_instance = nil # For scope
+  begin
+    sleep aws.class::WAIT_INTERVAL
+    former_live_instance = aws.lookup_instance(live_instance_id)
+    aws.class::LOGGER.info("Instance #{live_instance_id} has ip: #{former_live_instance.public_ip_address}")
+  end until former_live_instance && former_live_instance.public_ip_address
+  
+  aws.class::LOGGER.info("About to assign DNS #{demo_domain_name} to former live instance IP (#{former_live_instance.public_ip_address})...")
+  aws.update_dns_a_record(ZONE_ID, demo_domain_name, former_live_instance.public_ip_address)
+  aws.class::LOGGER.info("ASSIGNED DNS #{demo_domain_name} to #{aws.lookup_dns(demo_domain_name)}")
 end

--- a/scripts/swap_both.rb
+++ b/scripts/swap_both.rb
@@ -1,41 +1,10 @@
-require_relative '../lib/aws_wrapper'
-require 'resolv'
+require_relative '../lib/eip_dns_swapper'
 
-ZONE_ID = 'Z1JB6V9RIBL7FX' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones:
-
-if ARGV.empty?
-  puts 'USAGE: Provide the name of the live server which should be switched with demo.'
-  exit
+if ARGV.count != 1
+  fail 'USAGE: Provide the name of the live server which should be switched with demo.'
 end
 
-live_domain_name = ARGV.shift
-demo_domain_name = "demo.#{live_domain_name}"
+name = ARGV.shift
+zone_id = 'Z1JB6V9RIBL7FX' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones:
 
-AwsWrapper.new.tap do |aws|
-  eip_ip = aws.lookup_dns(live_domain_name)
-  demo_ip = aws.lookup_dns(demo_domain_name)
-  fail("Live and demo are both #{demo_ip}") if eip_ip == demo_ip
-
-  live_instance_id = aws.lookup_eip(eip_ip).instance_id
-
-  demo_instance = aws.lookup_ip(demo_ip)
-
-  aws.class::LOGGER.info("About to assign EIP #{eip_ip} to former demo instance (#{demo_instance.instance_id})...")
-  aws.assign_eip(eip_ip, demo_instance)
-  aws.class::LOGGER.info("ASSIGNED EIP #{eip_ip} to #{aws.lookup_eip(eip_ip).instance_id}")
-  
-  # At this point the live_instance object is out of date:
-  # The object's public_ip_address is actually still the EIP.
-  # So, look it up again:
-  
-  former_live_instance = nil # For scope
-  begin
-    sleep aws.class::WAIT_INTERVAL
-    former_live_instance = aws.lookup_instance(live_instance_id)
-    aws.class::LOGGER.info("Instance #{live_instance_id} has ip: #{former_live_instance.public_ip_address}")
-  end until former_live_instance && former_live_instance.public_ip_address
-  
-  aws.class::LOGGER.info("About to assign DNS #{demo_domain_name} to former live instance IP (#{former_live_instance.public_ip_address})...")
-  aws.update_dns_a_record(ZONE_ID, demo_domain_name, former_live_instance.public_ip_address)
-  aws.class::LOGGER.info("ASSIGNED DNS #{demo_domain_name} to #{aws.lookup_dns(demo_domain_name)}")
-end
+EipDnsSwapper.new.swap(name, zone_id)

--- a/scripts/swap_both.rb
+++ b/scripts/swap_both.rb
@@ -2,7 +2,6 @@ require_relative '../lib/aws_wrapper'
 require 'resolv'
 
 ZONE_ID = 'Z1JB6V9RIBL7FX' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones:
-AWS_WRAPPER = AwsWrapper.instance
 
 if ARGV.empty?
   puts 'USAGE: Provide the name of the live server which should be switched with demo.'
@@ -12,23 +11,18 @@ end
 live_domain_name = ARGV.shift
 demo_domain_name = "demo.#{live_domain_name}"
 
-def lookup(domain_name)
-  aws_ip = AWS_WRAPPER.lookup_dns_a_record(ZONE_ID, domain_name)
-  dns_ip = Resolv.getaddress(domain_name)
-  fail("Discrepancy for #{domain_name}: AWS=#{aws_ip} but DNS=#{dns_ip}") unless dns_ip == aws_ip
-  dns_ip
+AwsWrapper.new.tap do |aws|
+  eip_ip = aws.lookup_dns(live_domain_name)
+  demo_ip = aws.lookup_dns(demo_domain_name)
+  fail("Live and demo are both #{demo_ip}") if eip_ip == demo_ip
+
+  live_instance_id = aws.lookup_eip(eip_ip).instance_id
+  live_instance = aws.lookup_instance(live_instance_id)
+
+  demo_instance = aws.lookup_ip(demo_ip)
+
+  aws.class::LOGGER.info("About to assign EIP (#{eip_ip}) to former demo instance...")
+  aws.assign_eip(eip_ip, demo_instance)
+  aws.class::LOGGER.info("About to assign #{demo_domain_name} to former live instance...")
+  aws.update_dns_a_record(ZONE_ID, demo_domain_name, live_instance.public_ip_address)
 end
-
-eip_ip = lookup(live_domain_name)
-demo_ip = lookup(demo_domain_name)
-fail("Live and demo are both #{demo_ip}") if eip_ip == demo_ip
-
-live_instance_id = AWS_WRAPPER.lookup_eip(eip_ip).instance_id
-live_instance = AWS_WRAPPER.lookup_instance(live_instance_id)
-
-demo_instance = AWS_WRAPPER.lookup_ip(demo_ip)
-
-AWS_WRAPPER.logger.info("About to assign EIP (#{eip_ip}) to former demo instance...")
-AWS_WRAPPER.assign_eip(eip_ip, demo_instance)
-AWS_WRAPPER.logger.info("About to assign #{demo_domain_name} to former live instance...")
-AWS_WRAPPER.update_dns_a_record(ZONE_ID, demo_domain_name, live_instance.public_ip_address)


### PR DESCRIPTION
@afred?
I think this fixes #6, apart from testing (#7). Found one new bug in the process: When the EIP is reassigned away, it takes a minute before the old instance is given a new plain public IP. 

The whole process can take 4 minutes, maybe more, and there's a lot going on under the hood. Is that acceptable? I guess it also depends on the one-hammer/two-hammer debate. Anyway, could also try:
- Begging AWS for more EIPs? The docs say you can ask.
- Split each site onto its own account? Would probably be more confusing for devs?

Somewhat useful article: http://cloudnative.io/blog/2015/02/the-dos-and-donts-of-bluegreen-deployment/