### PR TITLE
Testing Ec2Wrapper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+sudo: false
+cache: bundler
+rvm:
+  - 2.0.0
+script: 'bundle exec rspec --tag ~not_on_travis'

--- a/spec/dns_wrapper_spec.rb
+++ b/spec/dns_wrapper_spec.rb
@@ -1,0 +1,5 @@
+require_relative '../lib/dns_wrapper'
+
+describe DnsWrapper do
+  # TODO
+end

--- a/spec/ec2_wrapper_spec.rb
+++ b/spec/ec2_wrapper_spec.rb
@@ -27,11 +27,25 @@ describe Ec2Wrapper do
   end
   
   describe '#assign_eip' do
-    # TODO
+    it 'makes expected calls to AWS' do
+      wrapper = TestWrapper.new
+      expect(wrapper).to receive(:ec2_client).and_return(
+        instance_double(Aws::EC2::Client).tap do |client|
+          expect(client).to receive(:associate_address)
+            .with(dry_run: false, instance_id: 'instance-id', public_ip: 'public.ip.address')
+        end
+      )
+      instance = instance_double(Aws::EC2::Instance).tap do |instance|
+        expect(instance).to receive(:instance_id).and_return('instance-id')
+      end
+      expect(wrapper.assign_eip('public.ip.address', instance)).to eq true
+    end
   end
   
   describe '#lookup_instance' do
-    # TODO
+    it 'makes expected calls to AWS' do
+      # TODO
+    end
   end
   
 end

--- a/spec/ec2_wrapper_spec.rb
+++ b/spec/ec2_wrapper_spec.rb
@@ -12,17 +12,18 @@ describe Ec2Wrapper do
       expect(wrapper).to receive(:ec2_client).and_return(
         instance_double(Aws::EC2::Client).tap do |client|
           expect(client).to receive(:describe_addresses)
-            .with(dry_run: false, public_ips: ["fake-eip-id"])
+            .with(dry_run: false, public_ips: ["eip-id"])
             .and_return(
               instance_double(Aws::EC2::Types::DescribeAddressesResult).tap do |result|
                 expect(result).to receive(:addresses)
-                  .and_return(['fake.eip.ip.address'])
+                  .and_return(['eip.ip.address'])
                   .exactly(2).times # for logging and for real
               end
             )
         end
       )
-      expect(wrapper.lookup_eip('fake-eip-id')).to eq 'fake.eip.ip.address'
+      
+      expect(wrapper.lookup_eip('eip-id')).to eq 'eip.ip.address'
     end
   end
   
@@ -38,13 +39,35 @@ describe Ec2Wrapper do
       instance = instance_double(Aws::EC2::Instance).tap do |instance|
         expect(instance).to receive(:instance_id).and_return('instance-id')
       end
+      
       expect(wrapper.assign_eip('public.ip.address', instance)).to eq true
     end
   end
   
   describe '#lookup_instance' do
     it 'makes expected calls to AWS' do
-      # TODO
+      wrapper = TestWrapper.new
+      expect(wrapper).to receive(:ec2_client).and_return(
+        instance_double(Aws::EC2::Client).tap do |client|
+          expect(client).to receive(:describe_instances)
+            .with(dry_run: false, instance_ids: ['instance-id'])
+            .and_return(
+              instance_double(Aws::EC2::Types::DescribeInstancesResult).tap do |result|
+                expect(result).to receive(:reservations)
+                  .and_return([
+                    instance_double(Aws::EC2::Types::Reservation).tap do |reservation|
+                      expect(reservation).to receive(:instances)
+                        .and_return([
+                          :instance
+                        ])
+                    end  
+                  ])
+              end
+            )
+        end
+      )
+      
+      expect(wrapper.lookup_instance('instance-id')).to eq :instance
     end
   end
   

--- a/spec/ec2_wrapper_spec.rb
+++ b/spec/ec2_wrapper_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../lib/ec2_wrapper'
+
+describe Ec2Wrapper do
+  
+  class TestWrapper
+    include Ec2Wrapper
+  end
+  
+  describe '#lookup_eip' do
+    it 'makes expected calls to AWS' do
+      wrapper = TestWrapper.new
+      expect(wrapper).to receive(:ec2_client).and_return(
+        instance_double(Aws::EC2::Client).tap do |client|
+          expect(client).to receive(:describe_addresses)
+            .with(dry_run: false, public_ips: ["fake-eip-id"])
+            .and_return(
+              instance_double(Aws::EC2::Types::DescribeAddressesResult).tap do |result|
+                expect(result).to receive(:addresses)
+                  .and_return(['fake.eip.ip.address'])
+                  .exactly(2).times # for logging and for real
+              end
+            )
+        end
+      )
+      expect(wrapper.lookup_eip('fake-eip-id')).to eq 'fake.eip.ip.address'
+    end
+  end
+  
+  describe '#assign_eip' do
+    # TODO
+  end
+  
+  describe '#lookup_instance' do
+    # TODO
+  end
+  
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+    mocks.verify_doubled_constant_names = true
+  end
+end


### PR DESCRIPTION
@afred: please review.
- The DnsWrapper still needs testing.
- What's next? Maybe actually using this for AB on stock sales?
- Where should it be run? On the deployer's computer? (Will run into ruby version issues.) ... Or run it on an AWS machine (not necessarily the webserver?) Security-wise, putting the AWS creds actually on a remote machine isn't super-encouraged, but not the end of the world either.