### PR TITLE
Fix ssh_opt.rb script with --just_ips option

### DIFF
--- a/lib/util/ssh_opter.rb
+++ b/lib/util/ssh_opter.rb
@@ -28,7 +28,7 @@ class SshOpter < AwsWrapper
     lookup_instance(instance_ids.first).public_ip_address
   end
 
-  def just_ips(zone_id, name)
-    [lookup_ip(zone_id, name), lookup_ip(zone_id, 'demo.' + name)]
+  def just_ips(name_tag)
+    lookup_public_ips_by_name(name_tag)
   end
 end

--- a/scripts/ssh_opt.rb
+++ b/scripts/ssh_opt.rb
@@ -29,7 +29,7 @@ ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name]
 
 if config[:just_ips]
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
-    .just_ips(config[:zone_id], config[:name]).join("\n")
+    .just_ips(config[:name]).join("\n")
 else
   prefix = /^demo\./
   if config[:name] !~ prefix


### PR DESCRIPTION
No longer requires that ELB and CNAMES have been set up.
Fixes #50.