### PR TITLE
Zone names 63

### DIFF
--- a/lib/core/dns_wrapper.rb
+++ b/lib/core/dns_wrapper.rb
@@ -9,7 +9,7 @@ module DnsWrapper
   end
 
   def lookup_cname(zone_name, name)
-    zone_id = lookup_zone_id(zone_name)
+    zone_id = lookup_zone(zone_name) # TODO: move this call into methods, so error messages can be name-based.
     cname_from_dns = Resolv::DNS.new.getresource(name, Resolv::DNS::Resource::IN::CNAME).name.to_s
     cname_from_aws = lookup_dns_cname_record(zone_id, name)
     if cname_from_dns != cname_from_aws
@@ -22,7 +22,7 @@ module DnsWrapper
   # both requests first, and then wait for them to complete.
 
   def delete_dns_cname_records(zone_name, domain_names)
-    zone_id = lookup_zone_id(zone_name)
+    zone_id = lookup_zone(zone_name)
     domain_names.map do |domain_name|
       request_delete_dns_cname_record(zone_id, domain_name)
     end.each do |request_id|
@@ -31,7 +31,7 @@ module DnsWrapper
   end
 
   def create_dns_cname_records(zone_name, domain_name_target_hash)
-    zone_id = lookup_zone_id(zone_name)
+    zone_id = lookup_zone(zone_name)
     domain_name_target_hash.map do |domain_name, target|
       request_create_dns_cname_record(zone_id, domain_name, target)
     end.each do |request_id|
@@ -54,7 +54,7 @@ module DnsWrapper
     end
   end
 
-  def lookup_zone_id(zone_name)
+  def lookup_zone(zone_name)
     response = dns_client.list_hosted_zones(
       max_items: 100
     )

--- a/lib/core/dns_wrapper.rb
+++ b/lib/core/dns_wrapper.rb
@@ -58,7 +58,8 @@ module DnsWrapper
     response = dns_client.list_hosted_zones(
       max_items: 100
     )
-    zones = Hash[response.hosted_zones.map { |zone| [zone.name, zone.id] }]
+    zones = Hash[response.hosted_zones.map { |zone| [zone.name, zone.id.sub(/.*\//, '')] }]
+    # Zone IDs returned by AWS are of the form '/hostedzone/ABCD1234'
     zones[zone_name]
   end
 

--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -4,7 +4,7 @@ require_relative 'aws_wrapper'
 
 class Builder < AwsWrapper
   def build(config)
-    zone_id = config[:zone_id]
+    zone_name = config[:zone_name]
     name = config[:name]
     skip_updates = config[:skip_updates]
     instance_type = config[:instance_type]
@@ -35,14 +35,14 @@ class Builder < AwsWrapper
 
       instance_ids.each do |instance_id|
         ip = lookup_instance(instance_id).public_ip_address
-        sudoer.sudo_by_ip(zone_id, name, commands_joined, ip)
+        sudoer.sudo_by_ip(zone_name, name, commands_joined, ip)
       end
     end
     LOGGER.info('Instances are up.')
   end
 
   def setup_load_balancer(config)
-    zone_id = config[:zone_id]
+    zone_name = config[:zone_name]
     name = config[:name]
 
     elb_names = elb_names(name)
@@ -61,7 +61,7 @@ class Builder < AwsWrapper
     LOGGER.info('Create group policy for ELB')
 
     name_target_pairs = cname_pair(name).zip(elb_a_names)
-    create_dns_cname_records(zone_id, name_target_pairs)
+    create_dns_cname_records(zone_name, name_target_pairs)
     LOGGER.info('Created CNAMEs')
   end
 end

--- a/lib/util/lister.rb
+++ b/lib/util/lister.rb
@@ -1,11 +1,11 @@
 require_relative 'aws_wrapper'
 
 class Lister < AwsWrapper
-  def list(zone_id, name, is_flat=true)
+  def list(zone_name, name, is_flat=true)
     list = {
       name: name,
       cnames: cname_pair(name).map do |cname|
-        cname_info(zone_id, cname)
+        cname_info(zone_name, cname)
       end
     }
     if is_flat
@@ -26,8 +26,8 @@ class Lister < AwsWrapper
 
   private
 
-  def cname_info(zone_id, cname)
-    elb_dns = lookup_cname(zone_id, cname)
+  def cname_info(zone_name, cname)
+    elb_dns = lookup_cname(zone_name, cname)
     elb = lookup_elb_by_dns_name(elb_dns)
     elb_name = elb.load_balancer_name
     {

--- a/lib/util/sudoer.rb
+++ b/lib/util/sudoer.rb
@@ -3,20 +3,20 @@ require_relative 'ssh_opter'
 require 'open3'
 
 class Sudoer < AwsWrapper
-  def sudo(zone_id, name, command, is_sudo=true) # TODO: rename method, use named params.
+  def sudo(zone_name, name, command, is_sudo=true) # TODO: rename method, use named params.
     command = 'sudo sh -c ' + sh_q(command) if is_sudo
-    ssh(ssh_opts(zone_id, name), command)
+    ssh(ssh_opts(zone_name, name), command)
   end
 
-  def sudo_by_ip(zone_id, name, command, ip)
+  def sudo_by_ip(zone_name, name, command, ip)
     command = 'sudo sh -c ' + sh_q(command)
-    ssh(ssh_opts(zone_id, name, ip), command)
+    ssh(ssh_opts(zone_name, name, ip), command)
   end
 
   private
 
-  def ssh_opts(zone_id, name, ip=nil)
-    SshOpter.new(availability_zone: @availability_zone).ssh_opts(zone_id, name, ip)
+  def ssh_opts(zone_name, name, ip=nil)
+    SshOpter.new(availability_zone: @availability_zone).ssh_opts(zone_name, name, ip)
   end
 
   def ssh(ssh_opts, command)

--- a/lib/util/swapper.rb
+++ b/lib/util/swapper.rb
@@ -2,12 +2,12 @@ require_relative 'aws_wrapper'
 require 'ostruct'
 
 class Swapper < AwsWrapper
-  def swap(zone_id, live_name)
+  def swap(zone_name, live_name)
     demo_name = 'demo.' + live_name
 
-    live = lookup_elb_and_instance(zone_id, live_name)
+    live = lookup_elb_and_instance(zone_name, live_name)
     LOGGER.info("live: #{live.elb_name} / #{live.instance_id}")
-    demo = lookup_elb_and_instance(zone_id, demo_name)
+    demo = lookup_elb_and_instance(zone_name, demo_name)
     LOGGER.info("demo: #{demo.elb_name} / #{demo.instance_id}")
 
     register_instance_with_elb(demo.instance_id, live.elb_name)
@@ -21,8 +21,8 @@ class Swapper < AwsWrapper
 
   private
 
-  def lookup_elb_and_instance(zone_id, name)
-    cname = lookup_cname(zone_id, name)
+  def lookup_elb_and_instance(zone_name, name)
+    cname = lookup_cname(zone_name, name)
     elb = lookup_elb_by_dns_name(cname)
     elb_name = elb.load_balancer_name
     instance_ids = elb.instances.map(&:instance_id)

--- a/scripts/build.rb
+++ b/scripts/build.rb
@@ -10,7 +10,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone',
     instance_type: 'EC2 instance type',
     image_id: 'Amazon machine image ID'
@@ -28,7 +28,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('After load balancer is set up, swap can be run.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name, :instance_type])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :instance_type])
 
 builder = Builder.new(debug: config[:debug], availability_zone: config[:availability_zone])
 

--- a/scripts/defaults.template.yml
+++ b/scripts/defaults.template.yml
@@ -1,4 +1,4 @@
-zone_id: 'Z1JB6V9RIBL7FX' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones
+zone_name: 'wgbh-mla-test.org.' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones
 availability_zone: 'us-east-1c'
 skip_updates: true
 instance_type: 'm3.medium'

--- a/scripts/destroy.rb
+++ b/scripts/destroy.rb
@@ -10,7 +10,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -22,7 +22,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('and then everything relating to the name is deleted.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
 
 print "Really destroy everything relating to #{config[:name]}? Reenter to confirm: "
 unless gets.strip == config[:name]
@@ -31,4 +31,4 @@ unless gets.strip == config[:name]
 end
 
 Destroyer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .destroy(config[:zone_id], config[:name], config[:unsafe])
+  .destroy(config[:zone_name], config[:name], config[:unsafe])

--- a/scripts/list.rb
+++ b/scripts/list.rb
@@ -11,7 +11,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -22,9 +22,9 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('Prints to STDOUT a JSON structure representing the resources under this name.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
 
 list = Lister.new(debug: config[:debug], availability_zone: config[:availability_zone])
-       .list(config[:zone_id], config[:name], config[:flat])
+       .list(config[:zone_name], config[:name], config[:flat])
 
 puts JSON.pretty_generate(list).gsub(/\s+([\]}])/, '\1')

--- a/scripts/rsync.rb
+++ b/scripts/rsync.rb
@@ -11,7 +11,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone',
     path: 'Path of dir to rsync'
   )
@@ -22,7 +22,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('Rsync the given directory from the live machine to demo.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name, :path])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :path])
 
 Rsyncer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .rsync(config[:zone_id], config[:name], config[:path])
+  .rsync(config[:zone_name], config[:name], config[:path])

--- a/scripts/ssh_opt.rb
+++ b/scripts/ssh_opt.rb
@@ -10,7 +10,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -29,14 +29,14 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('... or just lists the IPs.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
 
 if config[:ips_by_tag]
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
     .ips_by_tag(config[:name]).join("\n")
 elsif config[:ips_by_dns]
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
-    .ip_by_dns(config[:zone_id], config[:name])
+    .ip_by_dns(config[:zone_name], config[:name])
 else
   prefix = /^demo\./
   if config[:name] !~ prefix
@@ -45,5 +45,5 @@ else
   end
 
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
-    .ssh_opts(config[:zone_id], config[:name])
+    .ssh_opts(config[:zone_name], config[:name])
 end

--- a/scripts/sudo.rb
+++ b/scripts/sudo.rb
@@ -19,7 +19,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('SSH and sudo what needs to be sudone.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name, :command])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :command])
 
 Sudoer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .sudo(config[:zone_id], config[:name], config[:command])
+  .sudo(config[:zone_name], config[:name], config[:command])

--- a/scripts/swap.rb
+++ b/scripts/swap.rb
@@ -11,7 +11,7 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_id: 'AWS Zone ID',
+    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -21,7 +21,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('When run, the instances behind the two load balancers are swapped.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_id, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
 
 Swapper.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .swap(config[:zone_id], config[:name])
+  .swap(config[:zone_name], config[:name])

--- a/spec/dns_wrapper_spec.rb
+++ b/spec/dns_wrapper_spec.rb
@@ -31,6 +31,13 @@ describe DnsWrapper do
   describe '#delete_dns_cname_records' do
     it 'makes expected SDK calls' do
       wrapper = mock_wrapper do |client|
+        allow(client).to receive(:list_hosted_zones).and_return(
+          instance_double(Aws::Route53::Types::ListHostedZonesResponse).tap do |response|
+            allow(response).to receive(:hosted_zones).and_return(
+              [OpenStruct.new(name: 'name', id: 'id')]
+            )
+          end
+        )
         allow(client).to receive(:list_resource_record_sets).and_return(
           instance_double(Aws::Route53::Types::ListResourceRecordSetsResponse).tap do |response|
             allow(response).to receive(:resource_record_sets).and_return(
@@ -52,6 +59,13 @@ describe DnsWrapper do
   describe '#create_dns_cname_records' do
     it 'makes expected SDK calls' do
       wrapper = mock_wrapper do |client|
+        allow(client).to receive(:list_hosted_zones).and_return(
+          instance_double(Aws::Route53::Types::ListHostedZonesResponse).tap do |response|
+            allow(response).to receive(:hosted_zones).and_return(
+              [OpenStruct.new(name: 'name', id: 'id')]
+            )
+          end
+        )
         expect(client).to receive(:change_resource_record_sets).and_return(
           OpenStruct.new(change_info: OpenStruct.new(id: 'id'))
         )

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -18,17 +18,6 @@ fi
 NAME=$@.wgbh-mla-test.org
 JUST_ONE_NAME=one-$NAME
 
-# Without "--unsafe" it requires DNS to be set up, which is one of the last steps in the build,
-# ... so this is a little scary, but probably what we want.
-# destroy.rb prompts you to re-enter name as confirmation, hence the "echo".
-trap "echo '######################';
-      echo '#';
-      echo '# See failure above';
-      echo '#';
-      echo '######################';
-      ( echo $JUST_ONE_NAME | ruby scripts/destroy.rb --unsafe --name $JUST_ONE_NAME --debug );
-      ( echo $NAME          | ruby scripts/destroy.rb --unsafe --name $NAME          --debug )" EXIT
-
 message()
 {
   echo
@@ -40,15 +29,38 @@ message()
   echo
 }
 
+fold_start()
+{
+  echo "travis_fold:start:$1"
+}
+
+fold_end()
+{
+  echo "travis_fold:end:$1"
+}
+
+# Without "--unsafe" it requires DNS to be set up, which is one of the last steps in the build,
+# ... so this is a little scary, but probably what we want.
+# destroy.rb prompts you to re-enter name as confirmation, hence the "echo".
+trap "message 'See failure above';
+      ( echo $JUST_ONE_NAME | ruby scripts/destroy.rb --unsafe --name $JUST_ONE_NAME --debug );
+      ( echo $NAME          | ruby scripts/destroy.rb --unsafe --name $NAME          --debug )" EXIT
+
 
 # Trying to run each script without args gives us the doc strings, 
 # and is a loose test of our arg parsing.
 
 message 'build.rb'
 ! ruby scripts/build.rb
+fold_start 'build_just_one'
 ruby scripts/build.rb --name $JUST_ONE_NAME --skip_updates --just_one --debug
+fold_end 'build_just_one'
+fold_start 'build_pair'
 ruby scripts/build.rb --name $NAME --skip_updates --debug
+fold_end 'build_pair'
+fold_start 'build_load_balancer'
 ruby scripts/build.rb --name $NAME --skip_updates --setup_load_balancer --debug
+fold_end 'build_load_balancer'
 
 message 'ssh_opt.rb'
 ! ruby scripts/ssh_opt.rb && ssh `ruby scripts/ssh_opt.rb --name demo.$NAME --debug` 'hostname; whoami'

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -20,6 +20,7 @@ JUST_ONE_NAME=one-$NAME
 
 message()
 {
+  echo "travis_fold:end:$LAST"
   echo
   echo '######################'
   echo '#'
@@ -27,16 +28,8 @@ message()
   echo '#'
   echo '######################'
   echo
-}
-
-fold_start()
-{
   echo "travis_fold:start:$1"
-}
-
-fold_end()
-{
-  echo "travis_fold:end:$1"
+  LAST=$1
 }
 
 # Without "--unsafe" it requires DNS to be set up, which is one of the last steps in the build,
@@ -52,15 +45,9 @@ trap "message 'See failure above';
 
 message 'build.rb'
 ! ruby scripts/build.rb
-fold_start 'build_just_one'
 ruby scripts/build.rb --name $JUST_ONE_NAME --skip_updates --just_one --debug
-fold_end 'build_just_one'
-fold_start 'build_pair'
 ruby scripts/build.rb --name $NAME --skip_updates --debug
-fold_end 'build_pair'
-fold_start 'build_load_balancer'
 ruby scripts/build.rb --name $NAME --skip_updates --setup_load_balancer --debug
-fold_end 'build_load_balancer'
 
 message 'ssh_opt.rb'
 ! ruby scripts/ssh_opt.rb && ssh `ruby scripts/ssh_opt.rb --name demo.$NAME --debug` 'hostname; whoami'

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -24,14 +24,28 @@ JUST_ONE_NAME=one-$NAME
 trap "( echo $JUST_ONE_NAME | ruby scripts/destroy.rb --unsafe --name $JUST_ONE_NAME --debug );
       ( echo $NAME          | ruby scripts/destroy.rb --unsafe --name $NAME          --debug )" EXIT
 
+message()
+{
+  echo
+  echo '######################'
+  echo '#'
+  echo '#' $1
+  echo '#'
+  echo '######################'
+  echo
+}
+
+
 # Trying to run each script without args gives us the doc strings, 
 # and is a loose test of our arg parsing.
 
+message 'build.rb'
 ! ruby scripts/build.rb
 ruby scripts/build.rb --name $JUST_ONE_NAME --skip_updates --just_one --debug
 ruby scripts/build.rb --name $NAME --skip_updates --debug
 ruby scripts/build.rb --name $NAME --skip_updates --setup_load_balancer --debug
 
+message 'ssh_opt.rb'
 ! ruby scripts/ssh_opt.rb && ssh `ruby scripts/ssh_opt.rb --name demo.$NAME --debug` 'hostname; whoami'
 ruby scripts/ssh_opt.rb --name demo.$NAME --ips_by_dns --debug
 ruby scripts/ssh_opt.rb --name $NAME --ips_by_dns --debug # Should differ from the above.
@@ -39,10 +53,16 @@ ruby scripts/ssh_opt.rb --name $NAME --ips_by_tag --debug # Should include both.
 
 TARGET=/home/ec2-user/rsync-target
 
+message 'sudo.rb'
 ! ruby scripts/sudo.rb && ruby scripts/sudo.rb --name demo.$NAME --command "mkdir $TARGET" --debug
+message 'swap.rb'
 ! ruby scripts/swap.rb && ruby scripts/swap.rb --name $NAME --debug
+message 'rsync.rb'
 ! ruby scripts/rsync.rb && ruby scripts/rsync.rb --name $NAME --path $TARGET --debug
+message 'group_add.rb'
 ! ruby scripts/group_add.rb && ruby scripts/group_add.rb --user travis_ci --group $NAME --debug
+message 'list.rb'
 ! ruby scripts/list.rb && ruby scripts/list.rb --name $NAME --flat --debug
 
+message 'destroy.rb'
 ! ruby scripts/destroy.rb # Real destroy call is in the trap.

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -21,7 +21,12 @@ JUST_ONE_NAME=one-$NAME
 # Without "--unsafe" it requires DNS to be set up, which is one of the last steps in the build,
 # ... so this is a little scary, but probably what we want.
 # destroy.rb prompts you to re-enter name as confirmation, hence the "echo".
-trap "( echo $JUST_ONE_NAME | ruby scripts/destroy.rb --unsafe --name $JUST_ONE_NAME --debug );
+trap "echo '######################';
+      echo '#';
+      echo '# See failure above';
+      echo '#';
+      echo '######################';
+      ( echo $JUST_ONE_NAME | ruby scripts/destroy.rb --unsafe --name $JUST_ONE_NAME --debug );
       ( echo $NAME          | ruby scripts/destroy.rb --unsafe --name $NAME          --debug )" EXIT
 
 message()


### PR DESCRIPTION
Use zone_name instead of zone_id. This makes the config a little less cryptic. @afred?

(Also a lot of tweaks to the output from everything.sh to make it more human-readable.)