### PR TITLE
Implicit zone name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Scripts for our most common interactions with AWS.
 For documentation on a particular script, run it without arguments.
 
 Before running any of the examples, you will need to have an AWS IAM user,
-with your API credentials in the conventional location, and also have a zone ID 
-for your Route 53 DNS zone. The zone ID could be passed as a command line
-argument in all the examples below, but you can also specify it just once in
-`scripts/defaults.yml`, as you can with all command line arguments.
+with your API credentials in the conventional location: `~/.aws/credentials`.
 
 Typically, bare servers can be set up:
 ```

--- a/lib/util/aws_wrapper.rb
+++ b/lib/util/aws_wrapper.rb
@@ -23,6 +23,10 @@ class AwsWrapper
       # log_formatter: Aws::Log::Formatter.new("REQUEST: :http_request_body\nRESPONSE: :http_response_body")
     }
   end
+  
+  def dns_zone(name)
+    name.sub(/^(.*\.)?(\w+\.\w+)$/, '$2') + '.'
+  end
 
   def sh_q(s)
     "'#{s.gsub('\'') { |_m| "'\\''" }}'"

--- a/lib/util/aws_wrapper.rb
+++ b/lib/util/aws_wrapper.rb
@@ -25,7 +25,7 @@ class AwsWrapper
   end
 
   def dns_zone(name)
-    name.sub(/^(.*\.)?(\w+\.\w+)$/, '$2') + '.'
+    name.sub(/^(.*\.)?([^.]+\.[^.]+)$/, '\2') + '.'
   end
 
   def sh_q(s)

--- a/lib/util/aws_wrapper.rb
+++ b/lib/util/aws_wrapper.rb
@@ -23,7 +23,7 @@ class AwsWrapper
       # log_formatter: Aws::Log::Formatter.new("REQUEST: :http_request_body\nRESPONSE: :http_response_body")
     }
   end
-  
+
   def dns_zone(name)
     name.sub(/^(.*\.)?(\w+\.\w+)$/, '$2') + '.'
   end

--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -4,12 +4,13 @@ require_relative 'aws_wrapper'
 
 class Builder < AwsWrapper
   def build(config)
-    zone_name = config[:zone_name]
     name = config[:name]
     skip_updates = config[:skip_updates]
     instance_type = config[:instance_type]
     image_id = config[:image_id]
     number = config[:just_one] ? 1 : 2
+    
+    zone_name = dns_zone(name)
 
     max_length = 30 # 32 is max for ELB names, and we append "-a" or "-b".
     fail("Name '#{name}' must not be longer than #{max_length} characters") if name.length > max_length

--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -10,8 +10,6 @@ class Builder < AwsWrapper
     image_id = config[:image_id]
     number = config[:just_one] ? 1 : 2
 
-    zone_name = dns_zone(name)
-
     max_length = 30 # 32 is max for ELB names, and we append "-a" or "-b".
     fail("Name '#{name}' must not be longer than #{max_length} characters") if name.length > max_length
 
@@ -43,7 +41,6 @@ class Builder < AwsWrapper
   end
 
   def setup_load_balancer(config)
-    zone_name = config[:zone_name]
     name = config[:name]
 
     elb_names = elb_names(name)
@@ -62,7 +59,7 @@ class Builder < AwsWrapper
     LOGGER.info('Create group policy for ELB')
 
     name_target_pairs = cname_pair(name).zip(elb_a_names)
-    create_dns_cname_records(zone_name, name_target_pairs)
+    create_dns_cname_records(dns_zone(name), name_target_pairs)
     LOGGER.info('Created CNAMEs')
   end
 end

--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -36,7 +36,7 @@ class Builder < AwsWrapper
 
       instance_ids.each do |instance_id|
         ip = lookup_instance(instance_id).public_ip_address
-        sudoer.sudo_by_ip(zone_name, name, commands_joined, ip)
+        sudoer.sudo_by_ip(name, commands_joined, ip)
       end
     end
     LOGGER.info('Instances are up.')

--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -9,7 +9,7 @@ class Builder < AwsWrapper
     instance_type = config[:instance_type]
     image_id = config[:image_id]
     number = config[:just_one] ? 1 : 2
-    
+
     zone_name = dns_zone(name)
 
     max_length = 30 # 32 is max for ELB names, and we append "-a" or "-b".

--- a/lib/util/destroyer.rb
+++ b/lib/util/destroyer.rb
@@ -5,7 +5,7 @@ require_relative 'lister'
 class Destroyer < AwsWrapper
   def destroy(name, unsafe=false)
     # We want to do as much cleaning as possible, hence the "rescue"s.
-    
+
     zone_name = dns_zone(name)
 
     if unsafe

--- a/lib/util/destroyer.rb
+++ b/lib/util/destroyer.rb
@@ -3,25 +3,27 @@ require_relative 'lister'
 
 # rubocop:disable Style/RescueModifier
 class Destroyer < AwsWrapper
-  def destroy(zone_id, name, unsafe=false)
+  def destroy(name, unsafe=false)
     # We want to do as much cleaning as possible, hence the "rescue"s.
+    
+    zone_name = dns_zone(name)
 
     if unsafe
-      unsafe_destroy(zone_id, name)
+      unsafe_destroy(zone_name, name)
     else
-      safe_destroy(zone_id, name)
+      safe_destroy(zone_name, name)
     end
   end
 
   private
 
-  def safe_destroy(zone_id, name)
+  def safe_destroy(zone_name, name)
     # More conservative: Create a list of related resources to delete.
     # The downside is that if a root resource has already been deleted,
     # (like a DNS record) we won't find the formerly dependent records.
 
     flat_list = Lister.new(debug: @debug, availability_zone: @availability_zone)
-                .list(zone_id, name, true)
+                .list(zone_name, name, true)
 
     flat_list[:groups].each do |group_name|
       delete_group_policy(group_name) rescue LOGGER.warn("Error deleting policy: #{$!} at #{$@}")

--- a/lib/util/lister.rb
+++ b/lib/util/lister.rb
@@ -1,7 +1,9 @@
 require_relative 'aws_wrapper'
 
 class Lister < AwsWrapper
-  def list(zone_name, name, is_flat=true)
+  def list(name, is_flat=true)
+    zone_name = dns_zone(name)
+    
     list = {
       name: name,
       cnames: cname_pair(name).map do |cname|

--- a/lib/util/lister.rb
+++ b/lib/util/lister.rb
@@ -3,7 +3,7 @@ require_relative 'aws_wrapper'
 class Lister < AwsWrapper
   def list(name, is_flat=true)
     zone_name = dns_zone(name)
-    
+
     list = {
       name: name,
       cnames: cname_pair(name).map do |cname|

--- a/lib/util/rsyncer.rb
+++ b/lib/util/rsyncer.rb
@@ -5,15 +5,14 @@ require 'ostruct'
 
 class Rsyncer < AwsWrapper
   def rsync(live_name, path)
-    zone_name = dns_zone(live_name)
     demo_name = 'demo.' + live_name
 
-    live_ip = SshOpter.new(debug: @debug, availability_zone: @availability_zone).lookup_ip(zone_name, live_name)
+    live_ip = SshOpter.new(debug: @debug, availability_zone: @availability_zone).lookup_ip(live_name)
     rsync_command = "rsync -ave 'ssh -A -o StrictHostKeyChecking=no -l ec2-user' --exclude=lost+found ec2-user@#{live_ip}:#{path}/ #{path}/"
     # -a: archive, -v: verbose, -e: for SSH agent forwarding.
     if_exists_rsync_command = "if [ -e #{path} ]; then #{rsync_command}; fi"
     # On the first swap the directory does not yet exist, and user does not have privs to create.
     LOGGER.info("Will login to demo, and rsync #{path} from live to demo using SSH agent forwarding, if target exists.")
-    Sudoer.new(debug: @debug, availability_zone: @availability_zone).sudo(zone_name, demo_name, if_exists_rsync_command, false)
+    Sudoer.new(debug: @debug, availability_zone: @availability_zone).sudo(demo_name, if_exists_rsync_command, false)
   end
 end

--- a/lib/util/rsyncer.rb
+++ b/lib/util/rsyncer.rb
@@ -4,15 +4,16 @@ require_relative 'sudoer'
 require 'ostruct'
 
 class Rsyncer < AwsWrapper
-  def rsync(zone_id, live_name, path)
+  def rsync(live_name, path)
+    zone_name = dns_zone(live_name)
     demo_name = 'demo.' + live_name
 
-    live_ip = SshOpter.new(debug: @debug, availability_zone: @availability_zone).lookup_ip(zone_id, live_name)
+    live_ip = SshOpter.new(debug: @debug, availability_zone: @availability_zone).lookup_ip(zone_name, live_name)
     rsync_command = "rsync -ave 'ssh -A -o StrictHostKeyChecking=no -l ec2-user' --exclude=lost+found ec2-user@#{live_ip}:#{path}/ #{path}/"
     # -a: archive, -v: verbose, -e: for SSH agent forwarding.
     if_exists_rsync_command = "if [ -e #{path} ]; then #{rsync_command}; fi"
     # On the first swap the directory does not yet exist, and user does not have privs to create.
     LOGGER.info("Will login to demo, and rsync #{path} from live to demo using SSH agent forwarding, if target exists.")
-    Sudoer.new(debug: @debug, availability_zone: @availability_zone).sudo(zone_id, demo_name, if_exists_rsync_command, false)
+    Sudoer.new(debug: @debug, availability_zone: @availability_zone).sudo(zone_name, demo_name, if_exists_rsync_command, false)
   end
 end

--- a/lib/util/ssh_opter.rb
+++ b/lib/util/ssh_opter.rb
@@ -1,7 +1,9 @@
 require_relative 'aws_wrapper'
 
 class SshOpter < AwsWrapper
-  def ssh_opts(zone_name, name, ip=nil)
+  def ssh_opts(name, ip=nil)
+    zone_name = dns_zone(name)
+    
     ssh_delete_identities = 'ssh-add -D'
     system(ssh_delete_identities) || fail("Failed '#{ssh_delete_identities}'")
     LOGGER.info("Deleted old identities from SSH agent: #{ssh_delete_identities}")

--- a/lib/util/ssh_opter.rb
+++ b/lib/util/ssh_opter.rb
@@ -3,7 +3,7 @@ require_relative 'aws_wrapper'
 class SshOpter < AwsWrapper
   def ssh_opts(name, ip=nil)
     zone_name = dns_zone(name)
-    
+
     ssh_delete_identities = 'ssh-add -D'
     system(ssh_delete_identities) || fail("Failed '#{ssh_delete_identities}'")
     LOGGER.info("Deleted old identities from SSH agent: #{ssh_delete_identities}")

--- a/lib/util/sudoer.rb
+++ b/lib/util/sudoer.rb
@@ -4,21 +4,19 @@ require 'open3'
 
 class Sudoer < AwsWrapper
   def sudo(name, command, is_sudo=true) # TODO: rename method, use named params.
-    zone_name = dns_zone(name)
     command = 'sudo sh -c ' + sh_q(command) if is_sudo
-    ssh(ssh_opts(zone_name, name), command)
+    ssh(ssh_opts(name), command)
   end
 
   def sudo_by_ip(name, command, ip)
-    zone_name = dns_zone(name)
     command = 'sudo sh -c ' + sh_q(command)
-    ssh(ssh_opts(zone_name, name, ip), command)
+    ssh(ssh_opts(name, ip), command)
   end
 
   private
 
-  def ssh_opts(zone_name, name, ip=nil)
-    SshOpter.new(availability_zone: @availability_zone).ssh_opts(zone_name, name, ip)
+  def ssh_opts(name, ip=nil)
+    SshOpter.new(availability_zone: @availability_zone).ssh_opts(name, ip)
   end
 
   def ssh(ssh_opts, command)

--- a/lib/util/sudoer.rb
+++ b/lib/util/sudoer.rb
@@ -3,12 +3,14 @@ require_relative 'ssh_opter'
 require 'open3'
 
 class Sudoer < AwsWrapper
-  def sudo(zone_name, name, command, is_sudo=true) # TODO: rename method, use named params.
+  def sudo(name, command, is_sudo=true) # TODO: rename method, use named params.
+    zone_name = dns_zone(name)
     command = 'sudo sh -c ' + sh_q(command) if is_sudo
     ssh(ssh_opts(zone_name, name), command)
   end
 
-  def sudo_by_ip(zone_name, name, command, ip)
+  def sudo_by_ip(name, command, ip)
+    zone_name = dns_zone(name)
     command = 'sudo sh -c ' + sh_q(command)
     ssh(ssh_opts(zone_name, name, ip), command)
   end

--- a/lib/util/swapper.rb
+++ b/lib/util/swapper.rb
@@ -2,7 +2,8 @@ require_relative 'aws_wrapper'
 require 'ostruct'
 
 class Swapper < AwsWrapper
-  def swap(zone_name, live_name)
+  def swap(live_name)
+    zone_name = dns_zone(live_name)
     demo_name = 'demo.' + live_name
 
     live = lookup_elb_and_instance(zone_name, live_name)

--- a/scripts/build.rb
+++ b/scripts/build.rb
@@ -10,7 +10,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone',
     instance_type: 'EC2 instance type',
     image_id: 'Amazon machine image ID'
@@ -28,7 +27,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('After load balancer is set up, swap can be run.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :instance_type])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name, :instance_type])
 
 builder = Builder.new(debug: config[:debug], availability_zone: config[:availability_zone])
 

--- a/scripts/defaults.template.yml
+++ b/scripts/defaults.template.yml
@@ -1,4 +1,3 @@
-zone_name: 'wgbh-mla-test.org.' # https://console.aws.amazon.com/route53/home?region=us-east-1#hosted-zones
 availability_zone: 'us-east-1c'
 skip_updates: true
 instance_type: 'm3.medium'

--- a/scripts/destroy.rb
+++ b/scripts/destroy.rb
@@ -10,7 +10,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -22,7 +21,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('and then everything relating to the name is deleted.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name])
 
 print "Really destroy everything relating to #{config[:name]}? Reenter to confirm: "
 unless gets.strip == config[:name]
@@ -31,4 +30,4 @@ unless gets.strip == config[:name]
 end
 
 Destroyer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .destroy(config[:zone_name], config[:name], config[:unsafe])
+  .destroy(config[:name], config[:unsafe])

--- a/scripts/list.rb
+++ b/scripts/list.rb
@@ -11,7 +11,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -22,9 +21,9 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('Prints to STDOUT a JSON structure representing the resources under this name.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name])
 
 list = Lister.new(debug: config[:debug], availability_zone: config[:availability_zone])
-       .list(config[:zone_name], config[:name], config[:flat])
+       .list(config[:name], config[:flat])
 
 puts JSON.pretty_generate(list).gsub(/\s+([\]}])/, '\1')

--- a/scripts/rsync.rb
+++ b/scripts/rsync.rb
@@ -11,7 +11,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone',
     path: 'Path of dir to rsync'
   )
@@ -22,7 +21,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('Rsync the given directory from the live machine to demo.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :path])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name, :path])
 
 Rsyncer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .rsync(config[:zone_name], config[:name], config[:path])
+  .rsync(config[:name], config[:path])

--- a/scripts/ssh_opt.rb
+++ b/scripts/ssh_opt.rb
@@ -10,7 +10,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -29,14 +28,14 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('... or just lists the IPs.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name])
 
 if config[:ips_by_tag]
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
     .ips_by_tag(config[:name]).join("\n")
 elsif config[:ips_by_dns]
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
-    .ip_by_dns(config[:zone_name], config[:name])
+    .ip_by_dns(config[:name])
 else
   prefix = /^demo\./
   if config[:name] !~ prefix
@@ -45,5 +44,5 @@ else
   end
 
   puts SshOpter.new(debug: config[:debug], availability_zone: config[:availability_zone])
-    .ssh_opts(config[:zone_name], config[:name])
+    .ssh_opts(config[:name])
 end

--- a/scripts/sudo.rb
+++ b/scripts/sudo.rb
@@ -19,7 +19,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('SSH and sudo what needs to be sudone.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name, :command])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name, :command])
 
 Sudoer.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .sudo(config[:zone_name], config[:name], config[:command])
+  .sudo(config[:name], config[:command])

--- a/scripts/swap.rb
+++ b/scripts/swap.rb
@@ -11,7 +11,6 @@ opt_parser = OptionParser.new do |opts|
   ScriptHelper.one_arg_opts(
     opts, config,
     name: 'Name to be used for PK, EBS, DNS, etc.',
-    zone_name: 'AWS Route 53 zone name',
     availability_zone: 'Availability Zone'
   )
   ScriptHelper.no_arg_opts(
@@ -21,7 +20,7 @@ opt_parser = OptionParser.new do |opts|
   opts.separator('When run, the instances behind the two load balancers are swapped.')
 end
 
-ScriptHelper.read_args(config, opt_parser, [:availability_zone, :zone_name, :name])
+ScriptHelper.read_args(config, opt_parser, [:availability_zone, :name])
 
 Swapper.new(debug: config[:debug], availability_zone: config[:availability_zone])
-  .swap(config[:zone_name], config[:name])
+  .swap(config[:name])

--- a/spec/dns_wrapper_spec.rb
+++ b/spec/dns_wrapper_spec.rb
@@ -73,7 +73,7 @@ describe DnsWrapper do
           OpenStruct.new(change_info: OpenStruct.new(status: 'INSYNC'))
         )
       end
-      expect { wrapper.create_dns_cname_records('zone-id', 'example.org' => 'target.example.org') }.not_to raise_error
+      expect { wrapper.create_dns_cname_records('zone-name', 'example.org' => 'target.example.org') }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Conceivably, a second level domain could be registered as a zone, but apart from that scenario, the zone named can be derived from the hostname, so we shouldn't need to specify it. (Particularly since it's one thing we keep tripping over.) The zone name construction happens at a middle level... could be pushed deeper, but I'm comfortable with it where it is. @afred?