### PR TITLE
Safe destroy bad args

### DIFF
--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -69,5 +69,4 @@ message 'group_add.rb'
 message 'list.rb'
 ! ruby scripts/list.rb && ruby scripts/list.rb --name $NAME --flat --debug
 message 'destroy.rb'
-! ruby scripts/destroy.rb && echo $NAME | ruby scripts/destroy.rb --name $NAME --debug
-# ('echo' satisfies prompt for confirmation.)
+! ruby scripts/destroy.rb # This will fail, and trap will clean up. 

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -68,6 +68,7 @@ message 'group_add.rb'
 ! ruby scripts/group_add.rb && ruby scripts/group_add.rb --user travis_ci --group $NAME --debug
 message 'list.rb'
 ! ruby scripts/list.rb && ruby scripts/list.rb --name $NAME --flat --debug
-
 message 'destroy.rb'
-! ruby scripts/destroy.rb # This will fail, and trap will clean up.
+! ruby scripts/destroy.rb && ruby scripts/destroy.rb --name $NAME --debug
+
+false # So that the trap will be called to exercise destroy.rb --unsafe

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -71,5 +71,3 @@ message 'list.rb'
 message 'destroy.rb'
 ! ruby scripts/destroy.rb && echo $NAME | ruby scripts/destroy.rb --name $NAME --debug
 # ('echo' satisfies prompt for confirmation.)
-
-false # So that the trap will be called to exercise destroy.rb --unsafe

--- a/spec/everything.sh
+++ b/spec/everything.sh
@@ -69,6 +69,7 @@ message 'group_add.rb'
 message 'list.rb'
 ! ruby scripts/list.rb && ruby scripts/list.rb --name $NAME --flat --debug
 message 'destroy.rb'
-! ruby scripts/destroy.rb && ruby scripts/destroy.rb --name $NAME --debug
+! ruby scripts/destroy.rb && echo $NAME | ruby scripts/destroy.rb --name $NAME --debug
+# ('echo' satisfies prompt for confirmation.)
 
 false # So that the trap will be called to exercise destroy.rb --unsafe


### PR DESCRIPTION
@foo4thought ? 

In trying to clean up a bad deployment, I hit this:
```
$ ruby scripts/destroy.rb --name aapb.wgbh-mla-test.org
Really destroy everything relating to aapb.wgbh-mla-test.org? Reenter to confirm: aapb.wgbh-mla-test.org
/Users/chuck_mccallum/starting/aws-wrapper/lib/util/lister.rb:4:in `list': wrong number of arguments (3 for 1..2) (ArgumentError)
        from /Users/chuck_mccallum/starting/aws-wrapper/lib/util/destroyer.rb:26:in `safe_destroy'
        from /Users/chuck_mccallum/starting/aws-wrapper/lib/util/destroyer.rb:14:in `destroy'
        from scripts/destroy.rb:33:in `<main>'
```

What's really going on is that in an earlier PR, we changed it so that the dns zone no longer needs to be specified explicitly by the user, which simplified the method signatures. The problem is that destroy.rb has two distinct modes, safe and unsafe, and we were only testing the latter, so a signature problem in the former wasn't noticed.