### PR TITLE
Makes all scripts executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,61 +10,61 @@ with your API credentials in the conventional location: `~/.aws/credentials`.
 
 Typically, bare servers can be set up:
 ```
-ruby scripts/build.rb --name abc.wgbh-mla-test.org
+bundle exec scripts/build.rb --name abc.wgbh-mla-test.org
 ```
 
 And then set up the load balancers:
 ```
-ruby scripts/build.rb --name abc.wgbh-mla-test.org --setup_load_balancer
+bundle exec scripts/build.rb --name abc.wgbh-mla-test.org --setup_load_balancer
 ```
 
 The current user is added to the priv group by default,
 but another user can be added to the group:
 ```
-ruby scripts/group_add.rb --user someone_else --group abc.wgbh-mla-test.org
+bundle exec scripts/group_add.rb --user someone_else --group abc.wgbh-mla-test.org
 ```
 
 and then that user can swap them:
 ```
-ruby scripts/swap.rb --name abc.wgbh-mla-test.org
+bundle exec scripts/swap.rb --name abc.wgbh-mla-test.org
 ```
 
 and then stop the demo instance to save money, and restart before the next swap:
 ```
-ruby scripts/stop.rb --name demo.abc.wgbh-mla-test.org
-ruby scripts/start.rb --name demo.abc.wgbh-mla-test.org
+bundle exec scripts/stop.rb --name demo.abc.wgbh-mla-test.org
+bundle exec scripts/start.rb --name demo.abc.wgbh-mla-test.org
 ```
 
 and rsync a given directory from live to demo:
 ```
-ruby scripts/rsync.rb --name abc.wgbh-mla-test.org --path /var/www/abc/something
+bundle exec scripts/rsync.rb --name abc.wgbh-mla-test.org --path /var/www/abc/something
 ```
 
 log in to the demo machine:
 ```
-ssh `ruby scripts/ssh_opt.rb --name demo.abc.wgbh-mla-test.org`
+ssh `bundle exec scripts/ssh_opt.rb --name demo.abc.wgbh-mla-test.org`
 ```
 
 or just get the IPs:
 ```
-ruby scripts/ssh_opt.rb --name demo.abc.wgbh-mla-test.org --ips_by_dns
-ruby scripts/ssh_opt.rb --name abc.wgbh-mla-test.org --ips_by_dns
-ruby scripts/ssh_opt.rb --name abc.wgbh-mla-test.org --ips_by_tag
+bundle exec scripts/ssh_opt.rb --name demo.abc.wgbh-mla-test.org --ips_by_dns
+bundle exec scripts/ssh_opt.rb --name abc.wgbh-mla-test.org --ips_by_dns
+bundle exec scripts/ssh_opt.rb --name abc.wgbh-mla-test.org --ips_by_tag
 ```
 
 or for a one-liner:
 ```
-ruby scripts/sudo.rb --name abc.wgbh-mla-test.org --command 'echo "I am sudo"'
+bundle exec scripts/sudo.rb --name abc.wgbh-mla-test.org --command 'echo "I am sudo"'
 ```
 
 to get a handle on all the dependent resources:
 ```
-ruby scripts/list.rb --name abc.wgbh-mla-test.org
+bundle exec scripts/list.rb --name abc.wgbh-mla-test.org
 ```
 
 and if this is development and we want to clear the slate:
 ```
-ruby scripts/destroy.rb --name abc.wgbh-mla-test.org
+bundle exec scripts/destroy.rb --name abc.wgbh-mla-test.org
 ```
 
 ## Organization

--- a/scripts/build.rb
+++ b/scripts/build.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/builder'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/destroy.rb
+++ b/scripts/destroy.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/destroyer'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/group_add.rb
+++ b/scripts/group_add.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/aws_wrapper' # The method we need is in core: no wrapper class needed.
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/list.rb
+++ b/scripts/list.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/lister'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/rsync.rb
+++ b/scripts/rsync.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/swapper'
 require_relative '../lib/util/rsyncer'
 require_relative '../lib/script_helper'

--- a/scripts/ssh_opt.rb
+++ b/scripts/ssh_opt.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/ssh_opter'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/start.rb
+++ b/scripts/start.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/starter_stopper'
 require_relative '../lib/util/sudoer'
 require_relative '../lib/script_helper'

--- a/scripts/stop.rb
+++ b/scripts/stop.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/starter_stopper'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/sudo.rb
+++ b/scripts/sudo.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/sudoer'
 require_relative '../lib/script_helper'
 require 'optparse'

--- a/scripts/swap.rb
+++ b/scripts/swap.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative '../lib/util/swapper'
 require_relative '../lib/util/rsyncer'
 require_relative '../lib/script_helper'


### PR DESCRIPTION
This allows you to use `bundle exec`, which is the recommended way to run
executables.

Also updates README with new way to run scripts.