### PR TITLE
Allows using existing key and group

### DIFF
--- a/lib/util/builder.rb
+++ b/lib/util/builder.rb
@@ -9,16 +9,26 @@ class Builder < AwsWrapper
     instance_type = config[:instance_type]
     image_id = config[:image_id]
     number = config[:just_one] ? 1 : 2
+    skip_create_key_pair = config[:skip_create_key_pair]
+    skip_create_group = config[:skip_create_group]
 
     max_length = 30 # 32 is max for ELB names, and we append "-a" or "-b".
     fail("Name '#{name}' must not be longer than #{max_length} characters") if name.length > max_length
 
-    create_key(name)
-    LOGGER.info("Created PK for #{name}")
+    if skip_create_key_pair
+      LOGGER.info("Skipping creating key pair: #{name}")
+    else
+      create_key(name)
+      LOGGER.info("Created key pair: #{name}")
+    end
 
-    create_group(name)
-    add_current_user_to_group(name)
-    LOGGER.info("Created group #{name}, and added current user")
+    if skip_create_group
+      LOGGER.info("Skipping creating group #{name}, and added current user")
+    else
+      create_group(name)
+      add_current_user_to_group(name)
+      LOGGER.info("Created group #{name}, and added current user")
+    end
 
     instance_ids = start_instances(number, name, instance_type, image_id).map(&:instance_id)
     LOGGER.info("Started #{number} EC2 instances #{instance_ids}")

--- a/scripts/build.rb
+++ b/scripts/build.rb
@@ -21,7 +21,9 @@ opt_parser = OptionParser.new do |opts|
     just_one: 'Create only a single instance',
     setup_load_balancer: 'Do not create instances, but instead set up ELBs for existing',
     debug: 'Turn on debug logging',
-    skip_updates: 'Skip updates'
+    skip_updates: 'Skip updates',
+    skip_create_key_pair: 'Skip creating the key pair',
+    skip_create_group: 'Skip creating the group'
   )
   opts.separator('With "--just_one", creates a single instance.')
   opts.separator('Without "--just_one", creates a pair of instances,')


### PR DESCRIPTION
When need to be able to build new machines that can be used as replacements for
instances in an existing demo/prod pair, but this is tricky because the 'name'
parameter is so pervasive as a convention in tying all the AWS resources
together. This PR adds a couple of flags that allow a build to skip the
creation of a Key pair and an IAM group, assuming that it can use a Key pair
and group that already exist, based on the given 'name' parameter.

Closes #89.